### PR TITLE
Add unzip function for Windows OS and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Extract the compressed MTL and OBJ files.
 
     npm run extract
     
-NOTE: The above will not work on Windows or other OSs that don't have gunzip utility on the command line path.  To work around this manually extract the *.gz files in assets/models/ directory, using any unzipping utility that supports gzip.  The game will not work until these files are extracted.
+NOTE: The above will not work on Windows or other OSs that don't have gunzip utility on the command line path.  To work around this please run "node src\unzip.js" on the commandline.
 
 Start the dev server.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Extract the compressed MTL and OBJ files.
 
     npm run extract
     
-NOTE: The above will not work on Windows or other OSs that don't have gunzip utility on the command line path.  To work around this please run "node src\unzip.js" on the commandline.
+
+
+Extract the compressed MTL and OBJ files for Windows OS.
+
+    npm run unzip
 
 Start the dev server.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "start": "node start.js",
         "extract": "gunzip -k assets/models/*.gz",
         "compress": "gzip -fk assets/models/*.{mtl,obj}",
-        "prettier": "node ./node_modules/.bin/prettier --write src/*.js assets/cmds/*.js"
+        "prettier": "node ./node_modules/.bin/prettier --write src/*.js assets/cmds/*.js",
+        "unzip": "node src/unzip.js"
     },
     "keywords": [],
     "author": "",

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -1,0 +1,19 @@
+var zlib = require('zlib');  
+var fs = require('fs'); 
+
+function decompress(inFilename, outFilename) { 
+  var unzip = zlib.createUnzip();  
+  var input = fs.createReadStream(inFilename);  
+  var output = fs.createWriteStream(outFilename);  
+  
+  input.pipe(unzip).pipe(output); 
+}
+
+decompress('assets/models/CLH_Computer.mtl.gz', 'assets/models/CLH_Computer.mtl');
+decompress('assets/models/CLH_Computer.obj.gz', 'assets/models/CLH_Computer.obj');
+decompress('assets/models/CLH_ep2_computer_high_poly.mtl.gz', 'assets/models/CLH_ep2_computer_high_poly.mtl');
+decompress('assets/models/CLH_ep2_computer_high_poly.obj.gz', 'assets/models/CLH_ep2_computer_high_poly.obj');
+decompress('assets/models/CLH_ep2_cyc_wall.mtl.gz', 'assets/models/CLH_ep2_cyc_wall.mtl');
+decompress('assets/models/CLH_ep2_cyc_wall.obj.gz', 'assets/models/CLH_ep2_cyc_wall.obj');
+decompress('assets/models/CLH_Shuttle.mtl.gz', 'assets/models/CLH_Shuttle.mtl');
+decompress('assets/models/CLH_Shuttle.obj.gz', 'assets/models/CLH_Shuttle.obj');


### PR DESCRIPTION
This will unzip all files located on asset/models/ when using Windows OS since npm extract script won't work on windows.